### PR TITLE
fix: corregir deprecaciones React 19 y eliminar any

### DIFF
--- a/locuventas_frontend/src/components/common/FormDialog.tsx
+++ b/locuventas_frontend/src/components/common/FormDialog.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import type { ReactNode, FormEvent } from "react";
+import type { ReactNode, SubmitEvent } from "react";
 import Boton from "@buttons/Boton";
 import BotonCerrar from "@buttons/BotonCerrar";
 
 interface FormDialogProps {
   visible:       boolean;
   onClose:       () => void;
-  onSubmit:      (e: FormEvent) => void;
+  onSubmit:      (e: SubmitEvent<HTMLFormElement>) => void;
   titulo:        string;
   botonTexto:    string;
   botonDisabled?: boolean;

--- a/locuventas_frontend/src/components/products/ModalProductoForm.tsx
+++ b/locuventas_frontend/src/components/products/ModalProductoForm.tsx
@@ -10,7 +10,7 @@ import type { SelectOption } from "@domain/ui.types";
 interface Props {
   visible:         boolean;
   onClose:         () => void;
-  onSubmit:        (e: React.FormEvent) => void;
+  onSubmit:        (e: React.SubmitEvent) => void;
   editando:        unknown;
   nombre:          string;
   setNombre:       (v: string) => void;

--- a/locuventas_frontend/src/docs/DONT_DO.md
+++ b/locuventas_frontend/src/docs/DONT_DO.md
@@ -1,0 +1,107 @@
+# Lo que NO hay que hacer
+
+Catálogo de patrones deprecados y malas prácticas detectadas y corregidas en el
+proyecto.
+
+---
+
+## React 19
+
+### `FormEvent` en onSubmit de formularios
+
+`FormEvent` está deprecado en React 19 para el evento `onSubmit` de formularios.
+El tipo correcto es `React.SubmitEvent` (o importado desde `"react"`).
+
+```tsx
+// ❌ MAL — FormEvent está deprecado en React 19 para onSubmit
+import type { FormEvent } from "react";
+<form onSubmit={(e: React.FormEvent) => { ... }}>
+onSubmit: (e: FormEvent) => void;
+
+// ✅ BIEN — SubmitEvent de React
+import type { SubmitEvent } from "react";
+<form onSubmit={(e: React.SubmitEvent) => { ... }}>
+onSubmit: (e: SubmitEvent) => void;
+// o con generic explícito:
+onSubmit: (e: SubmitEvent<HTMLFormElement>) => void;
+```
+
+> ⚠️ No confundir con el tipo nativo DOM `SubmitEvent` (sin import). Ese es
+> otro tipo incompatible. Siempre importar desde `"react"`.
+
+**Archivos corregidos:**
+- `src/components/common/FormDialog.tsx`
+- `src/components/products/ModalProductoForm.tsx`
+- `src/hooks/useGestionProductos.ts`
+
+---
+
+## TypeScript
+
+### `any` en catch
+
+```tsx
+// ❌ MAL
+catch (err: any) {
+  toast.error(err?.error);
+}
+```
+
+```tsx
+// ✅ BIEN — usar unknown y castear explícitamente
+catch (err: unknown) {
+  const e = err as Record<string, string | undefined>;
+  toast.error(e?.error ?? "Error");
+}
+```
+
+**Archivos corregidos:**
+- `src/hooks/useGestionProductos.ts`
+
+---
+
+### `any` en estado o parámetros
+
+```tsx
+// ❌ MAL
+const [editando, setEditando] = useState<any | null>(null);
+const abrirEditar = (prod: any, ...) => { ... };
+```
+
+```tsx
+// ✅ BIEN — importar y usar el tipo de dominio correspondiente
+import type { Producto } from "@domain/producto.types";
+const [editando, setEditando] = useState<Producto | null>(null);
+const abrirEditar = (prod: Producto, ...) => { ... };
+```
+
+**Archivos corregidos:**
+- `src/hooks/useGestionProductos.ts`
+
+---
+
+### `React.ComponentType<any>` en mapas dinámicos
+
+No se encontró una alternativa limpia — el `any` sigue siendo necesario mientras
+los componentes del mapa tengan firmas de props distintas. Pendiente de resolver
+en un refactor futuro.
+
+```tsx
+// ⚠️ CASO ESPECIAL — workaround documentado
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const PANEL_MAP: Record<string, React.ComponentType<any>> = { PendientesList };
+```
+
+**Archivo:**
+- `src/components/common/RecursiveMenu.tsx`
+
+---
+
+## Recordatorio general
+
+| Patrón | Estado |
+|--------|--------|
+| `FormEvent` → `React.SubmitEvent` | ✅ Corregido |
+| `catch (err: any)` → `unknown` + cast | ✅ Corregido |
+| `useState<any>` → tipo concreto (`Producto`) | ✅ Corregido |
+| `ComponentType<any>` en `PANEL_MAP` | ⏳ Pendiente |

--- a/locuventas_frontend/src/hooks/useGestionProductos.ts
+++ b/locuventas_frontend/src/hooks/useGestionProductos.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { toast } from "react-toastify";
 import { apiRequest } from "@services/api";
 import type { SelectOption } from "@domain/ui.types";
+import type { Producto } from "@domain/producto.types";
 
 interface FormState {
   nombre:         string;
@@ -40,7 +41,7 @@ const API_URL = import.meta.env.VITE_API_URL as string;
 
 export default function useGestionProductos({ onSuccess }: UseGestionProductosOptions) {
   const [form,     setForm]     = useState<FormState>(FORM_INITIAL);
-  const [editando, setEditando] = useState<any | null>(null);
+  const [editando, setEditando] = useState<Producto | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [modal,    setModal]    = useState<ModalState>({ visible: false });
 
@@ -53,7 +54,7 @@ export default function useGestionProductos({ onSuccess }: UseGestionProductosOp
     setShowForm(true);
   };
 
-  const abrirEditar = (prod: any, paises: SelectOption[], categorias: SelectOption[]) => {
+  const abrirEditar = (prod: Producto, paises: SelectOption[], categorias: SelectOption[]) => {
     setEditando(prod);
     const rutaFoto = prod.foto?.includes("/") ? prod.foto : `productos/${prod.foto}`;
 
@@ -87,12 +88,13 @@ export default function useGestionProductos({ onSuccess }: UseGestionProductosOp
       toast.success(id ? "Producto editado" : "Producto creado");
       cerrarForm();
       onSuccess();
-    } catch (err: any) {
-      toast.error(err?.foto ?? err?.error ?? "Error guardando producto");
+    } catch (err: unknown) {
+      const e = err as Record<string, string | undefined>;
+      toast.error(e?.foto ?? e?.error ?? "Error guardando producto");
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     const { nombre, precio, paisId, categoriaIds, foto, iva } = form;
 
@@ -152,11 +154,12 @@ export default function useGestionProductos({ onSuccess }: UseGestionProductosOp
           await apiRequest(`productos/${id}`, null, { method: "DELETE" });
           toast.success("Producto eliminado correctamente.");
           onDeleteSuccess();
-        } catch (err: any) {
-          if (err?.razon === "EN_VENTA") {
+        } catch (err: unknown) {
+          const er = err as Record<string, string | undefined>;
+          if (er?.razon === "EN_VENTA") {
             toast.warn("No puedes eliminar este producto porque ya ha sido vendido.");
           } else {
-            toast.error(err?.error ?? "No se pudo eliminar el producto.");
+            toast.error(er?.error ?? "No se pudo eliminar el producto.");
           }
         }
       },


### PR DESCRIPTION
- FormEvent → React.SubmitEvent en onSubmit de formularios (3 archivos)
- catch (err: any) → unknown + cast explícito en useGestionProductos
- useState<any> → Producto | null, parámetro any → Producto
- docs: crear DONT_DO.md con catálogo de patrones prohibidos