### PR TITLE
refactor: extraer skeletons inline a archivos independientes

### DIFF
--- a/locuventas_frontend/CLAUDE.md
+++ b/locuventas_frontend/CLAUDE.md
@@ -274,7 +274,7 @@ Se migraron todos los dominios a `src/features/` siguiendo la estructura `{domai
 | `refactor/phase2-button` | Unificar `Boton`, `BotonClaro`, `BotonCerrar`, `Enlace` → `Button` con `variant` | ✅ Mergeado |
 | `refactor/phase2-select` | Extraer lógica compartida en `SelectBase` + renombrar `SelectFieldset` → `SelectForm`, `SelectFiltro` → `SelectFilter` | ✅ Mergeado |
 | `refactor/phase2-upload` | Unificar `UploadComponent` + `UploadAvatar` → `ImageUpload` con `shape` | ✅ |
-| `refactor/phase2-skeleton` | Unificar `SkeletonProductoCard`, `SkeletonTarjetaVendedor` e inlines → `Skeleton` con `variant` | 🔲 |
+| `refactor/phase2-skeleton` | Extraer skeletons inline a archivos independientes: `SkeletonVentaCard`, `SkeletonProductoGestionCard` | ✅ |
 
 ### Fase 3 🔲 — Refactor arquitectura
 - Crear `usePaginatedFetch<T>` genérico para eliminar el patrón repetido en hooks de fetch paginado
@@ -306,7 +306,13 @@ Para retomar el trabajo, abrir el chat y empezar con: **"Continúa con el roadma
   - Eliminados: `UploadComponent.tsx`, `features/auth/components/UploadAvatar.tsx`
   - 3 imports actualizados (ModalProductoForm, FormEditarPerfil, FormVendedorRegister)
   - Build verificado
-- Siguiente paso: **Phase 2 — Skeleton** (unificar en `Skeleton` con `variant`)
+- **Phase 2: Skeleton** — skeletons inline extraídos a archivos independientes ✅
+  - `SkeletonVentaCard.tsx` creado en `features/ventas/components/`
+  - `SkeletonProductoGestionCard.tsx` creado en `features/productos/components/`
+  - Eliminada duplicación inline en `ContenedorVentas.tsx` y `GestionProductos.tsx`
+  - `SkeletonProductoCard` (standalone, catálogo) y `FilaSkeleton` (DataTable) quedan como están
+  - Build verificado
+- Siguiente paso: **Fase 3 — Refactor arquitectura** (usePaginatedFetch, mover PrivateRoute → app/, FooterLogin → common/)
 
 ### Convención de nombres de ramas
 

--- a/locuventas_frontend/src/docs/MIGRATION_PLAN.md
+++ b/locuventas_frontend/src/docs/MIGRATION_PLAN.md
@@ -78,7 +78,7 @@ src/features/
 | `refactor/phase2-button` | Unificar `Boton`, `BotonClaro`, `Enlace` → `Button` con `variant` | ✅ |
 | `refactor/rename-selects` | Extraer lógica compartida en `SelectBase` + renombrar `SelectFieldset` → `SelectForm`, `SelectFiltro` → `SelectFilter` | ✅ |
 | **`refactor/phase2-upload`** | **Unificar `UploadComponent` + `UploadAvatar` → `ImageUpload` con `shape`** | **✅** |
-| `refactor/phase2-skeleton` | Unificar `SkeletonProductoCard`, `SkeletonTarjetaVendedor` e inlines → `Skeleton` con `variant` | 🔲 |
+| `refactor/phase2-skeleton` | Extraer skeletons inline a archivos independientes: `SkeletonVentaCard`, `SkeletonProductoGestionCard` | ✅ |
 
 ## Fase 3 — Refactor arquitectura 🔲
 

--- a/locuventas_frontend/src/features/productos/components/GestionProductos.tsx
+++ b/locuventas_frontend/src/features/productos/components/GestionProductos.tsx
@@ -7,6 +7,7 @@ import useBreakpoint from "@hooks/useBreakpoint";
 import { isBreakpoint } from "@constants/breakpoints";
 import TablaProductos from "./TablaProductos";
 import ProductoGestionCard from "./ProductoGestionCard";
+import SkeletonProductoGestionCard from "./SkeletonProductoGestionCard";
 import ModalProductoForm from "./ModalProductoForm";
 import ModalConfirmacion from "@components/common/ModalConfirmacion";
 import Paginacion from "@components/common/Paginacion";
@@ -14,27 +15,6 @@ import BuscadorInput from "@components/common/BuscadorInput";
 import SelectFilter from "@components/common/SelectFilter";
 import FAB from "@components/common/FAB";
 import Button from "@buttons/Button";
-
-const SkeletonProductoCard = () => (
-  <div className="rounded-2xl bg-zinc-900 border border-zinc-700 flex flex-col gap-3 p-4 animate-pulse">
-    <div className="flex justify-between items-center">
-      <div className="h-3 w-8 bg-zinc-700 rounded" />
-      <div className="flex gap-2">
-        <div className="h-8 w-14 bg-zinc-700 rounded-xl" />
-        <div className="h-8 w-16 bg-zinc-700 rounded-xl" />
-      </div>
-    </div>
-    <div className="h-28 bg-zinc-800 rounded-xl border border-zinc-700/30" />
-    <div className="flex flex-col gap-2">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="flex justify-between">
-          <div className="h-3 w-16 bg-zinc-700/50 rounded" />
-          <div className="h-3 w-24 bg-zinc-700/50 rounded" />
-        </div>
-      ))}
-    </div>
-  </div>
-);
 
 export default function GestionProductos() {
   const bp = useBreakpoint();
@@ -145,7 +125,7 @@ export default function GestionProductos() {
         <div className="flex flex-col gap-4 pb-16">
           {loading
             ? Array.from({ length: size }).map((_, i) => (
-                <SkeletonProductoCard key={i} />
+                <SkeletonProductoGestionCard key={i} />
               ))
             : productos.length === 0
               ? (

--- a/locuventas_frontend/src/features/productos/components/SkeletonProductoGestionCard.tsx
+++ b/locuventas_frontend/src/features/productos/components/SkeletonProductoGestionCard.tsx
@@ -1,0 +1,22 @@
+export default function SkeletonProductoGestionCard() {
+  return (
+    <div className="rounded-2xl bg-zinc-900 border border-zinc-700 flex flex-col gap-3 p-4 animate-pulse">
+      <div className="flex justify-between items-center">
+        <div className="h-3 w-8 bg-zinc-700 rounded" />
+        <div className="flex gap-2">
+          <div className="h-8 w-14 bg-zinc-700 rounded-xl" />
+          <div className="h-8 w-16 bg-zinc-700 rounded-xl" />
+        </div>
+      </div>
+      <div className="h-28 bg-zinc-800 rounded-xl border border-zinc-700/30" />
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex justify-between">
+            <div className="h-3 w-16 bg-zinc-700/50 rounded" />
+            <div className="h-3 w-24 bg-zinc-700/50 rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/locuventas_frontend/src/features/ventas/components/ContenedorVentas.tsx
+++ b/locuventas_frontend/src/features/ventas/components/ContenedorVentas.tsx
@@ -1,29 +1,10 @@
 import type { Venta } from "../domain/venta.types";
 import TablaVentas from "./TablaVentas";
 import VentaCard from "./VentaCard";
+import SkeletonVentaCard from "./SkeletonVentaCard";
 import Paginacion from "@components/common/Paginacion";
 import useBreakpoint from "@hooks/useBreakpoint";
 import { isBreakpoint } from "@constants/breakpoints";
-
-const SkeletonVentaCard = () => (
-  <div className="rounded-2xl bg-zinc-900 border border-zinc-700 flex flex-col gap-3 p-4 w-full animate-pulse">
-    <div className="flex justify-between items-center">
-      <div className="h-4 w-12 bg-zinc-700 rounded" />
-      <div className="h-5 w-16 bg-zinc-700 rounded-full" />
-    </div>
-    <div className="flex flex-col gap-2">
-      {Array.from({ length: 3 }).map((_, i) => (
-        <div key={i} className="flex justify-between">
-          <div className="h-3 w-16 bg-zinc-700/50 rounded" />
-          <div className="h-3 w-24 bg-zinc-700/50 rounded" />
-        </div>
-      ))}
-    </div>
-    <div className="flex flex-col gap-2 pt-2 border-t border-zinc-800">
-      <div className="h-8 bg-zinc-700/50 rounded-xl" />
-    </div>
-  </div>
-);
 
 interface Props {
   ventas:       Venta[];

--- a/locuventas_frontend/src/features/ventas/components/SkeletonVentaCard.tsx
+++ b/locuventas_frontend/src/features/ventas/components/SkeletonVentaCard.tsx
@@ -1,0 +1,21 @@
+export default function SkeletonVentaCard() {
+  return (
+    <div className="rounded-2xl bg-zinc-900 border border-zinc-700 flex flex-col gap-3 p-4 w-full animate-pulse">
+      <div className="flex justify-between items-center">
+        <div className="h-4 w-12 bg-zinc-700 rounded" />
+        <div className="h-5 w-16 bg-zinc-700 rounded-full" />
+      </div>
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex justify-between">
+            <div className="h-3 w-16 bg-zinc-700/50 rounded" />
+            <div className="h-3 w-24 bg-zinc-700/50 rounded" />
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-col gap-2 pt-2 border-t border-zinc-800">
+        <div className="h-8 bg-zinc-700/50 rounded-xl" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Creado SkeletonVentaCard.tsx en features/ventas/components/
- Creado SkeletonProductoGestionCard.tsx en features/productos/components/
- Eliminado inline SkeletonVentaCard de ContenedorVentas.tsx
- Eliminado inline SkeletonProductoCard duplicado de GestionProductos.tsx
- SkeletonProductoCard (standalone, catalogo) y FilaSkeleton (DataTable) quedan como estan
- Docs actualizados: MIGRATION_PLAN.md, CLAUDE.md